### PR TITLE
fixed mysql error with mysql version 8.x

### DIFF
--- a/includes/modules/profile.php
+++ b/includes/modules/profile.php
@@ -786,7 +786,7 @@ if (isset($id) && getnickname($id) != '' && deleteduser($id) == '0') {
         $specialtype = "";
         $getrank = safe_query(
             "SELECT IF
-                (u.special_rank = 0, 0, CONCAT_WS('__', r.rank, r.pic)) as RANK
+                (u.special_rank = 0, 0, CONCAT_WS('__', r.rank, r.pic)) as `RANK`
             FROM
                 " . PREFIX . "user u LEFT JOIN " . PREFIX . "plugins_forum_ranks r ON u.special_rank = r.rankID
             WHERE


### PR DESCRIPTION
RANK is a reserved keyword in mysql 8
so you have to escape RANK with `` to fix this issue.